### PR TITLE
Added http2, brotli, zlib and manual

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,10 +53,26 @@ tar xfJ \${TARBALL_PATH}
 cd curl-*
 
 echo "***Installing build dependencies..."
-apk add gcc make musl-dev openssl-dev openssl-libs-static file
+apk add gcc make musl-dev openssl-dev openssl-libs-static file \
+        nghttp2-static nghttp2-dev \
+        brotli-static brotli-dev \
+        zlib-static zlib-dev \
+        groff
+
+# Fix for libbrotlidec:
+cd /usr/lib
+ar -M <<AREOF
+create libbrotlidec.a
+addlib libbrotlidec-static.a
+addlib libbrotlicommon-static.a
+save
+end
+AREOF
+
+cd /tmp/build/curl-*
 
 echo "***configuring..."
-./configure --disable-shared --with-ca-fallback
+./configure --enable-manual --disable-shared --with-ca-fallback
 echo "making..."
 make curl_LDFLAGS=-all-static
 


### PR DESCRIPTION
Added features to the static linked curl:
- http2 - with nghttp2 package
- brotli - with brotli package
- zlib - with zlib package

Installed groff for generating full featured manual inside portable executable.