### PR TITLE
use openssl for build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ echo "***Installing build dependencies..."
 apk add gcc make musl-dev openssl-dev openssl-libs-static file
 
 echo "***configuring..."
-./configure --disable-shared --with-ca-fallback
+./configure --disable-shared --with-ca-fallback --with-openssl
 echo "making..."
 make curl_LDFLAGS=-all-static
 


### PR DESCRIPTION
version 7.77.0 of curl requires the explicit declaration of an tls backend.
Because build.sh install openssl directly before the call to configure I suggest using "--with-openssl"